### PR TITLE
Add release automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,14 @@
+## What does this PR do?
+
+[//]: # (Required: Describe the effects of your pull request in detail. If
+multiple changes are involved, a bulleted list is often useful.)
+
+## What gif best describes this PR or how it makes you feel?
+
+[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)
+
+## Completion checklist
+
+- [ ] Additions and changes have unit tests
+- [ ] Unit tests, Pylint, security testing, and Integration tests are passing. GitHub actions does this automatically
+- [ ] The pull request has been appropriately labeled using the provided PR labels

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,41 @@
+name-template: '$RESOLVED_VERSION 🌈'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'quick-fix'
+  - title: '🧰 Maintenance'
+    label:
+      - 'chore'
+      - 'maintenance'
+      - 'maintain'
+      - 'cleanup'
+  - title: '📝 Documentation'
+    label:
+      - 'documentation'
+      - 'docs'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,31 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Bump version
+        run: |
+          version_file="metabadger/bin/version.py"
+
+          # https://github.com/bridgecrewio/checkov/blob/master/.github/workflows/build.yml#L87-L132
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch --tags
+          git pull origin main
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "latest tag: $latest_tag"
+          new_tag=$(echo $latest_tag | awk -F. -v a="$1" -v b="$2" -v c="$3" '{printf("%d.%d.%d", $1+a, $2+b , $3+1)}')
+          echo "new tag: $new_tag"
+
+          printf "# pylint: disable=missing-module-docstring\n__version__ = '$new_tag'""" > $version_file
+
+          git commit -m "Bump to ${new_tag}"  $version_file || echo "No changes to commit"
+          git push origin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: Publish
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          make setup-dev
+      - name: Run pytest (unit tests) and bandit (security test)
+        run: |
+          make security-test
+          make test
+
+      - name: Install the package to make sure nothing is randomly broken
+        run: |
+          make install
+
+#  publish-package:
+#    needs: test
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@master
+#      - name: Set up Python 3.7
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.7
+#      - name: Install dependencies
+#        run: |
+#          pip install -r requirements.txt
+#          pip install -r requirements-dev.txt
+#      - name: create python package
+#        run: |
+#          git config --local user.email "action@github.com"
+#          git config --local user.name "GitHub Action"
+#          git fetch --tags
+#          git pull origin main
+#          pip install setuptools wheel twine
+#          python -m setup sdist bdist_wheel
+#      - name: Publish package
+#        uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_PASSWORD }}
+
+  bump-version:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Bump version
+        run: |
+          version_file="metabadger/bin/version.py"
+
+          # https://github.com/bridgecrewio/checkov/blob/master/.github/workflows/build.yml#L87-L132
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch --tags
+          git pull origin main
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "latest tag: $latest_tag"
+          new_tag=$(echo $latest_tag | awk -F. -v a="$1" -v b="$2" -v c="$3" '{printf("%d.%d.%d", $1+a, $2+b , $3+1)}')
+          echo "new tag: $new_tag"
+
+          printf "# pylint: disable=missing-module-docstring\n__version__ = '$new_tag'""" > $version_file
+
+          git commit -m "Bump to ${new_tag}"  $version_file || echo "No changes to commit"
+          git push origin

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ main, master ]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a few different GitHub actions that will be helpful.

* [Release Drafter](https://github.com/release-drafter/release-drafter): Automatically drafts your next release notes as PRs are merged. Once you feel like you want to push a new release, you just click on "Create release" from the draft. Example release notes: https://github.com/salesforce/cloudsplaining/releases
* Version bump automation: This automatically bumps the version in metabadger/bin/version.py so you don't have to manually modify that file. You can manually trigger this action. Additionally, after you publish a new release, GitHub actions will go back and update that file in a new commit to the main branch.
* PyPi publish automation: That exists in the publish.yml file. It won't work until you add a valid PYPI_USERNAME (always `__token__`) and PYPI_PASSWORD value (generated by PyPi) in GitHub actions. But once you are ready, you can uncomment that part of the file and it will automatically publish that to PyPi when you cut a new release.
* Also includes a Pull request template. This also requires that people include dank memes in their PRs which is very important.